### PR TITLE
fix: add line height to unsortable columns on sortable datatable (#9311)

### DIFF
--- a/packages/styles/scss/components/data-table/sort/_data-table-sort.scss
+++ b/packages/styles/scss/components/data-table/sort/_data-table-sort.scss
@@ -70,6 +70,7 @@
     > .#{$prefix}--table-header-label {
     padding-right: $spacing-05;
     padding-left: $spacing-05;
+    line-height: 1;
   }
 
   // -------------------------------------


### PR DESCRIPTION
Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
